### PR TITLE
feat: Redis를 이용한 세션관리 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,12 @@ repositories {
 }
 
 dependencies {
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.data:spring-data-redis:3.2.0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
     implementation 'io.github.cdimascio:dotenv-java:2.2.4'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'

--- a/src/main/java/personal_project/moment_talk/common/RedisConfig.java
+++ b/src/main/java/personal_project/moment_talk/common/RedisConfig.java
@@ -16,7 +16,7 @@ public class RedisConfig {
     public ObjectMapper objectMapper() {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
-        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO-8601 형식 사용
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         return mapper;
     }
 
@@ -25,10 +25,8 @@ public class RedisConfig {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
 
-        // ObjectMapper 기반 GenericJackson2JsonRedisSerializer 설정
         GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
 
-        // Key와 Value 직렬화기 설정
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(serializer);
         template.setHashKeySerializer(new StringRedisSerializer());

--- a/src/main/java/personal_project/moment_talk/common/RedisConfig.java
+++ b/src/main/java/personal_project/moment_talk/common/RedisConfig.java
@@ -1,0 +1,40 @@
+package personal_project.moment_talk.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO-8601 형식 사용
+        return mapper;
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory, ObjectMapper objectMapper) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        // ObjectMapper 기반 GenericJackson2JsonRedisSerializer 설정
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        // Key와 Value 직렬화기 설정
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(serializer);
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(serializer);
+
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/src/main/java/personal_project/moment_talk/common/WebConfig.java
+++ b/src/main/java/personal_project/moment_talk/common/WebConfig.java
@@ -1,0 +1,20 @@
+package personal_project.moment_talk.common;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import personal_project.moment_talk.session.service.SessionInterceptor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final SessionInterceptor sessionInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(sessionInterceptor)
+                .addPathPatterns("/**");
+    }
+}

--- a/src/main/java/personal_project/moment_talk/session/config/RedisEventListenerConfig.java
+++ b/src/main/java/personal_project/moment_talk/session/config/RedisEventListenerConfig.java
@@ -1,0 +1,32 @@
+package personal_project.moment_talk.session.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+import org.springframework.stereotype.Component;
+import personal_project.moment_talk.user.repository.UserRepository;
+
+@Configuration
+public class RedisEventListenerConfig {
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            RedisConnectionFactory connectionFactory,
+            MessageListenerAdapter listenerAdapter) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(listenerAdapter, new PatternTopic("__keyevent@*__:expired"));
+        return container;
+    }
+
+    @Bean
+    public MessageListenerAdapter listenerAdapter(RedisKeyExpirationListener listener) {
+        return new MessageListenerAdapter(listener);
+    }
+}

--- a/src/main/java/personal_project/moment_talk/session/config/RedisKeyExpirationListener.java
+++ b/src/main/java/personal_project/moment_talk/session/config/RedisKeyExpirationListener.java
@@ -1,0 +1,41 @@
+package personal_project.moment_talk.session.config;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+import personal_project.moment_talk.user.repository.UserRepository;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisKeyExpirationListener implements MessageListener {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        log.info("Expired key");
+        String expiredKey = message.toString(); // 만료된 Redis 키
+        handleExpiredKey(expiredKey);
+    }
+
+    private void handleExpiredKey(String key) {
+
+        // Redis 키에서 User 관련 데이터를 추출 (예: user:sessionId 형식의 키를 사용하는 경우)
+        String sessionId = extractSessionIdFromKey(key);
+
+        // UserRepository를 사용하여 isActive를 false로 업데이트
+        userRepository.findBySessionId(sessionId).ifPresent(user -> {
+            user.expireSession();
+            userRepository.save(user);
+        });
+    }
+
+    private String extractSessionIdFromKey(String key) {
+        // 키 파싱 로직 (예: "user:sessionId" 형식일 경우 sessionId 추출)
+        return key.replace("session:", "");
+    }
+}

--- a/src/main/java/personal_project/moment_talk/session/config/RedisKeyExpirationListener.java
+++ b/src/main/java/personal_project/moment_talk/session/config/RedisKeyExpirationListener.java
@@ -18,16 +18,14 @@ public class RedisKeyExpirationListener implements MessageListener {
     @Override
     public void onMessage(Message message, byte[] pattern) {
         log.info("Expired key");
-        String expiredKey = message.toString(); // 만료된 Redis 키
+        String expiredKey = message.toString();
         handleExpiredKey(expiredKey);
     }
 
     private void handleExpiredKey(String key) {
 
-        // Redis 키에서 User 관련 데이터를 추출 (예: user:sessionId 형식의 키를 사용하는 경우)
         String sessionId = extractSessionIdFromKey(key);
 
-        // UserRepository를 사용하여 isActive를 false로 업데이트
         userRepository.findBySessionId(sessionId).ifPresent(user -> {
             user.expireSession();
             userRepository.save(user);
@@ -35,7 +33,6 @@ public class RedisKeyExpirationListener implements MessageListener {
     }
 
     private String extractSessionIdFromKey(String key) {
-        // 키 파싱 로직 (예: "user:sessionId" 형식일 경우 sessionId 추출)
         return key.replace("session:", "");
     }
 }

--- a/src/main/java/personal_project/moment_talk/session/service/RedisSessionService.java
+++ b/src/main/java/personal_project/moment_talk/session/service/RedisSessionService.java
@@ -1,0 +1,42 @@
+package personal_project.moment_talk.session.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class RedisSessionService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void saveSession(String sessionId, Long userId) {
+        String key = "session:" + sessionId;
+        redisTemplate.opsForHash().put(key, "userId", userId);
+        redisTemplate.opsForHash().put(key, "createdAt", LocalDateTime.now());
+        redisTemplate.expire(key, Duration.ofMinutes(60));
+    }
+
+    public void refreshSession(String sessionId) {
+        String key = "session:" + sessionId;
+        Long timeout = 3600L;
+
+        if (redisTemplate.hasKey(key)) {
+            redisTemplate.expire(key, timeout, TimeUnit.SECONDS);
+        }
+    }
+
+    public Long getUserIdFromSession(String sessionId) {
+        String key = "session:" + sessionId;
+        return (Long) redisTemplate.opsForHash().get(key, "userId");
+    }
+
+    public void deleteSession(String sessionId) {
+        String key = "session:" + sessionId;
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/personal_project/moment_talk/session/service/SessionInterceptor.java
+++ b/src/main/java/personal_project/moment_talk/session/service/SessionInterceptor.java
@@ -1,0 +1,30 @@
+package personal_project.moment_talk.session.service;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class SessionInterceptor implements HandlerInterceptor {
+
+    private final RedisSessionService redisSessionService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("JSESSIONID".equals(cookie.getName())) {
+                    String sessionId = cookie.getValue();
+                    redisSessionService.refreshSession(sessionId);
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/personal_project/moment_talk/session/service/SessionService.java
+++ b/src/main/java/personal_project/moment_talk/session/service/SessionService.java
@@ -1,0 +1,23 @@
+package personal_project.moment_talk.session.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import personal_project.moment_talk.user.entity.User;
+import personal_project.moment_talk.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class SessionService {
+
+    private final UserRepository userRepository;
+    private final RedisSessionService redisSessionService;
+
+    public void checkSession(String sessionId) {
+        if (userRepository.findBySessionId(sessionId).isPresent()) return;
+        String userName = "Anonymous_" + sessionId.substring(0, 8);
+        User user = new User(userName, sessionId);
+        userRepository.save(user);
+        redisSessionService.saveSession(sessionId, user.getId());
+    }
+
+}

--- a/src/main/java/personal_project/moment_talk/user/controller/UserController.java
+++ b/src/main/java/personal_project/moment_talk/user/controller/UserController.java
@@ -4,20 +4,20 @@ import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import personal_project.moment_talk.session.service.SessionService;
 import personal_project.moment_talk.user.service.UserService;
 
 @Controller
 @RequiredArgsConstructor
 public class UserController {
 
-    private final UserService userService;
+    private final SessionService sessionService;
 
     @GetMapping("/")
     public String mainPage(HttpSession session) {
 
         String sessionId = session.getId();
-
-        userService.checkUserIsExists(sessionId);
+        sessionService.checkSession(sessionId);
 
         return "mainPage";
     }

--- a/src/main/java/personal_project/moment_talk/user/entity/User.java
+++ b/src/main/java/personal_project/moment_talk/user/entity/User.java
@@ -19,8 +19,15 @@ public class User extends AbstractBaseTime {
     @Column(unique = true)
     private String sessionId;
 
+    private boolean isActive;
+
     public User(String userName, String sessionId) {
         this.userName = userName;
         this.sessionId = sessionId;
+        this.isActive = true;
+    }
+
+    public void expireSession() {
+        this.isActive = false;
     }
 }

--- a/src/main/java/personal_project/moment_talk/user/repository/UserRepository.java
+++ b/src/main/java/personal_project/moment_talk/user/repository/UserRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findBySessionId(String sessionId);
+
+    Long countByIsActive(boolean isActive);
 }

--- a/src/main/java/personal_project/moment_talk/user/service/UserService.java
+++ b/src/main/java/personal_project/moment_talk/user/service/UserService.java
@@ -11,13 +11,5 @@ public class UserService {
 
     private final UserRepository userRepository;
 
-    public void checkUserIsExists(String sessionId) {
-        User user = userRepository.findBySessionId(sessionId).orElse(null);
 
-        if ( user == null) {
-            String userName = "Anonymous_" + sessionId.substring(0, 8);
-            user = new User(userName, sessionId);
-            userRepository.save(user);
-        }
-    }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,12 +8,19 @@ spring:
     username: ${DATABASE_USER_NAME}
     password: ${DATABASE_USER_PASSWORD}
     driver-class-name: ${DATABASE_DRIVER}
-
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:
         format_sql: true
     open-in-view: false
+  session:
+    store-type: redis
+  cache:
+    type: redis
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: 6379


### PR DESCRIPTION
https://github.com/I-migi/MomentTalk/issues/1#issue-2753769948

### Redis 설정 클래스

- ObjectMapper Bean
    - JSON 직렬화 역직렬화 설정
    - JavaTimeModule → Java 8 이상의 날짜 객체를 처리하려면 필요
    - `mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);` → 날짜 직렬화 시 타임스태프 대신 ISO 방식으로 사용(”2024-12-21..”)
    - 직렬화(Serialization): 객체 → JSON
    - 역직렬화(Deserialization): JSON → 객체
- RedisTemplate Bean
    - Redis와 데이터를 주고받을 때 설정
- GenericJackson2JsonRedisSerializer → Jackson의 ObjectMapper를 기반으로 JSON 형식으로 데이터를 직렬화, 역직렬화, 타입 정보를 함께 저장 → 역직렬화 시 원래 타입으로 복원

→ Redis에 데이터를 저장하거나 조회할 때 타입 안정성과 가독성 확보

WebConfig

- sessionInterceptor를 다른 모든 요청 전에 실행

RedisEventListenerConfig

→ Redis 이벤트 리스너를 설정하기 위한 클래스 → Redis에서 발생하는 특정 이벤트를 수신 → 처리하는 Listener설정

RedisMessageListenerContainer: Redis 메시지를 비동기적으로 수신하는 데 사용

addMessageListener: 리스너와 주제 설정

→ Redis에서 Keyspace Notifications 는 기본적으로 비활성화 → Redis서버에서
`config set notify-keyspace-events Ex` 명령어를 입력 해 설정 활성화 필요