### PR TITLE
feat: DeepL API를 이용한 채팅 번역기능 구현

### DIFF
--- a/src/main/java/personal_project/moment_talk/chat/controller/ChatController.java
+++ b/src/main/java/personal_project/moment_talk/chat/controller/ChatController.java
@@ -1,13 +1,40 @@
 package personal_project.moment_talk.chat.controller;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
+import personal_project.moment_talk.chat.service.DeepLTranslationService;
 
+import java.util.Map;
+
+@Slf4j
 @Controller
+@RequiredArgsConstructor
 public class ChatController {
+
+    private final DeepLTranslationService deepLTranslationService;
 
     @GetMapping("/instant-connect")
     public String instantConnect() {
         return "instant-connect";
+    }
+
+    /*
+    클라이언트가 보낸 JSON 데이터를 Map<String, String> 형태로 자동 변환
+    translatedText(번역된 text) = deepLTranslationService.translate(text);
+     */
+    @ResponseBody
+    @PostMapping("/translate")
+    public Map<String, String> translate(@RequestBody Map<String, String> request) {
+        String text = request.get("text");
+        log.info("Translate text : {}", text);
+
+        String translatedText = deepLTranslationService.translate(text);
+
+        return Map.of("translatedText", translatedText);
     }
 }

--- a/src/main/java/personal_project/moment_talk/chat/service/DeepLTranslationService.java
+++ b/src/main/java/personal_project/moment_talk/chat/service/DeepLTranslationService.java
@@ -1,0 +1,101 @@
+package personal_project.moment_talk.chat.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DeepLTranslationService {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${DEEPL_API_KEY}")
+    private String apiKey;
+
+    @Value("${DEEPL_API_END_POINT}")
+    private String endPoint;
+
+    public String translate(String text) {
+        String detectedLanguage = detectLanguage(text); // 텍스트가 한글인지 영어인지 감지
+        String targetLanguage = detectedLanguage.equals("ko") ? "en" : "ko";
+
+        try {
+            HttpEntity<MultiValueMap<String, String>> requestEntity = makeDeepLPostEntity(text, detectedLanguage, targetLanguage);
+
+            /* DeepL API 호출
+            POST 요청을 실행하고, DeepL API 의 응답을 ResponseEntity 객체로 받음.
+            요청 대상: endPoint
+            요청 본문: requestEntity
+            응답 형식: String
+             */
+            ResponseEntity<String> response = restTemplate.postForEntity(endPoint, requestEntity, String.class);
+
+            log.info("Raw Response: {}", response.getBody());
+
+            // ObjectMapper: Jackson 라이브러리를 사용해 JSON 문자열을 Java 객체로 변환
+            ObjectMapper objectMapper = new ObjectMapper();
+            // DeepL 의 JSON 응답을 Map<String, Object> 형태로 변환
+            Map<String, Object> responseMap = objectMapper.readValue(response.getBody(), Map.class);
+
+            if (responseMap.containsKey("translations")) {
+                List<Map<String, String>> translations = (List<Map<String, String>>) responseMap.get("translations");
+                String translatedText = translations.get(0).get("text");
+
+                // URL 디코딩 처리
+                String decodedText = translatedText;
+                if (translatedText.contains("%")) {
+                    decodedText = URLDecoder.decode(translatedText, StandardCharsets.UTF_8);
+                }
+
+                log.info("Translated Text (Decoded): {}", decodedText);
+                return decodedText;
+            }
+        } catch (Exception e) {
+            log.error("Error while translating text", e);
+        }
+
+        // 번역 실패 시 null 반환
+        return null;
+    }
+
+    private HttpEntity<MultiValueMap<String, String>> makeDeepLPostEntity(String text, String detectedLanguage, String targetLanguage) {
+        // POST 요청 본문을 생성하기 위해 사용 -> key-value 형태로 데이터를 구성
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("auth_key", apiKey);
+        body.add("text", text);
+        body.add("source_lang", detectedLanguage.toUpperCase());
+        body.add("target_lang", targetLanguage.toUpperCase());
+
+        // 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        // HHTP 요청 본문(body) 와 헤더 결합하여 하나의 요청 엔티티 객체로 생성
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(body, headers);
+        return requestEntity;
+    }
+
+    // 텍스트가 한글인지 영어인지 감지
+    public String detectLanguage(String text) {
+        if (text.matches(".*[ㄱ-ㅎㅏ-ㅣ가-힣]+.*")) { // 한글 포함 여부 확인
+            return "ko";
+        }
+        return "en"; // 기본적으로 영어로 간주
+    }
+}

--- a/src/main/java/personal_project/moment_talk/common/WebConfig.java
+++ b/src/main/java/personal_project/moment_talk/common/WebConfig.java
@@ -1,7 +1,9 @@
 package personal_project.moment_talk.common;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import personal_project.moment_talk.common.filter.SessionInterceptor;
@@ -21,5 +23,15 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(sessionInterceptor)
                 .addPathPatterns("/**");
+    }
+
+
+    /*
+    RestTemplate 는 Spring 에서 HTTP 요청을 보내고 응답을 처리하는 데 사용되는 클래스
+    RestTemplate 객체를 스프링 빈으로 등록해 애플리케이션 전역에서 주입받아 사용할 수 있게 함
+     */
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,7 +10,7 @@ spring:
     driver-class-name: ${DATABASE_DRIVER}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:

--- a/src/main/resources/templates/instant-connect.html
+++ b/src/main/resources/templates/instant-connect.html
@@ -67,6 +67,25 @@
             box-shadow: 7px 7px 20px rgba(90, 103, 216, 0.4);
         }
 
+        #backButton {
+            margin-top: 20px;
+            padding: 10px 20px;
+            background: linear-gradient(90deg, #ff7e5f, #feb47b);
+            color: #ffffff;
+            border: none;
+            border-radius: 15px;
+            font-size: 1rem;
+            cursor: pointer;
+            transition: background 0.3s ease, transform 0.2s ease;
+            box-shadow: 5px 5px 15px rgba(255, 126, 95, 0.3);
+        }
+
+        #backButton:hover {
+            background: linear-gradient(90deg, #ff6a3d, #fd935d);
+            transform: translateY(-4px);
+            box-shadow: 7px 7px 20px rgba(255, 106, 61, 0.4);
+        }
+
         #chatBox {
             display: none;
             flex-direction: column;
@@ -94,6 +113,14 @@
             box-sizing: border-box; /* Ensure padding doesn't overflow the width */
         }
 
+        #chatMessages .message-time {
+            font-size: 0.8rem;
+            color: #bbb;
+            margin-left: 10px;
+            align-self: flex-end; /* 시간을 오른쪽에 정렬 */
+        }
+
+
         #chatMessages .message-sent {
             background-color: #667eea;
             color: #ffffff;
@@ -114,6 +141,25 @@
             border-radius: 20px 20px 20px 0;
             max-width: 70%;
             word-wrap: break-word;
+            position: relative;
+            display: flex; /* 버튼 정렬을 위한 플렉스 컨테이너 */
+            align-items: center; /* 세로 중앙 정렬 */
+        }
+
+        #chatMessages .message-received:hover .translate-button {
+            display: inline-block; /* 마우스를 올릴 때만 보이도록 설정 */
+        }
+
+        .translate-button {
+            display: none; /* 기본적으로 숨김 */
+            margin-left: 10px;
+            padding: 5px 10px;
+            font-size: 0.8rem;
+            background: #f1f1f1;
+            color: #333;
+            border: 1px solid #ddd;
+            border-radius: 10px;
+            cursor: pointer;
         }
 
         #chatInput {
@@ -156,6 +202,7 @@
             <input type="text" id="messageInput" placeholder="Type your message...">
             <button id="sendButton">Send</button>
         </div>
+        <button id="backButton">뒤로가기</button> <!-- Add here -->
     </div>
 </div>
 <script>
@@ -166,42 +213,49 @@
     const sendButton = document.getElementById("sendButton");
     const connectButton = document.getElementById("connectButton");
 
+    const backButton = document.getElementById("backButton");
+
+    backButton.addEventListener("click", () => {
+        resetUI();
+        if (socket && socket.readyState === WebSocket.OPEN) {
+            socket.close(); // Close the WebSocket connection on exit
+        }
+    });
+
+
+
+
     let socket = null;
 
     // Initialize WebSocket
     function initWebSocket() {
         socket = new WebSocket("ws://localhost:8080/ws/connect");
+        // socket = new WebSocket("ws://192.168.129.100:8080/ws/connect");
 
         socket.onopen = () => {
-            console.log("WebSocket connected");
             statusDiv.textContent = "새로운 친구를 찾는 중...";
         };
 
         socket.onmessage = (event) => {
-            console.log("Message received: ", event.data);
-
             if (event.data.startsWith("MATCH_SUCCESS:")) {
                 const opponentUser = event.data.split(":")[1];
                 statusDiv.style.display = "none";
                 connectButton.style.display = "none";
-                chatBox.style.display = "flex"; // Show chatbox
-                console.log("Matched with user: ", opponentUser);
-            } else if (event.data === "WAITING_FOR_MATCH") {
-                statusDiv.textContent = "새로운 친구를 찾는 중...";
-            } else if (event.data === "NO_MATCH_FOUND") {
-                alert("채팅을 원하는 친구가 없습니다. 몇 분 후 다시 시도해주세요");
-                resetUI();
-            } else if (event.data === "USER_DISCONNECTED") {
-                alert("상대방이 채팅방에서 나갔습니다.");
-                resetUI();
+                chatBox.style.display = "flex";
             } else {
+                const currentTime = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+
                 const messageDiv = document.createElement("div");
                 messageDiv.className = "message-received";
-                messageDiv.textContent = event.data;
+
+                messageDiv.innerHTML = `<span>${event.data}</span>
+                                <button class="translate-button" data-message="${event.data}">번역</button>
+                                <span class="message-time">${currentTime}</span>`;
                 chatMessages.appendChild(messageDiv);
                 chatMessages.scrollTop = chatMessages.scrollHeight;
             }
         };
+
 
         socket.onclose = () => {
             console.log("WebSocket closed");
@@ -220,11 +274,12 @@
         connectButton.style.display = "inline-block";
         connectButton.disabled = false;
         chatBox.style.display = "none";
-        chatMessages.innerHTML = "";
+        chatMessages.innerHTML = ""; // Clear chat messages
         if (socket && socket.readyState === WebSocket.OPEN) {
-            socket.close();
+            socket.close(); // Ensure the WebSocket is closed
         }
     }
+
 
     connectButton.addEventListener("click", () => {
         connectButton.disabled = true;
@@ -256,9 +311,14 @@
 
         if (message && socket && socket.readyState === WebSocket.OPEN) {
             socket.send(message);
+
             const messageDiv = document.createElement("div");
             messageDiv.className = "message-sent";
-            messageDiv.textContent = `You: ${message}`;
+
+            // 현재 시간 추가
+            const currentTime = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+
+            messageDiv.innerHTML = `<span>You: ${message}</span> <span class="message-time">${currentTime}</span>`;
             chatMessages.appendChild(messageDiv);
             chatMessages.scrollTop = chatMessages.scrollHeight;
             messageInput.value = "";
@@ -267,6 +327,50 @@
         }
     }
 
+
+    document.addEventListener("click", async (event) => {
+        if (event.target.classList.contains("translate-button")) {
+            const button = event.target;
+            const originalMessage = button.getAttribute("data-message");
+
+            // 번역 요청
+            const translatedMessage = await translateMessage(originalMessage);
+
+            if (translatedMessage) {
+                // URL 디코딩하여 사용자에게 표시
+                const decodedMessage = decodeURIComponent(translatedMessage);
+
+                // 원래 메시지 대체
+                const messageElement = button.previousElementSibling;
+                messageElement.textContent = decodedMessage;
+
+                // 버튼 제거 또는 "번역 완료" 표시
+                button.textContent = "번역 완료";
+                button.disabled = true;
+            }
+        }
+    });
+
+    async function translateMessage(message) {
+        try {
+            const response = await fetch("/translate", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ text: message }) // targetLanguage 제거
+            });
+
+            if (response.ok) {
+                const data = await response.json();
+                return data.translatedText; // 번역된 텍스트 반환
+            } else {
+                console.error("Translation failed");
+                return null;
+            }
+        } catch (error) {
+            console.error("Error during translation:", error);
+            return null;
+        }
+    }
 
 
     window.addEventListener("beforeunload", () => {


### PR DESCRIPTION
DeepL API를 이용한 채팅 번역기능 구현(한->영, 영->한)

## 발생 이슈와 해결

## **이슈 1: `detected_source_language`가 잘못 감지됨**

### **문제**

- 한국어 텍스트가 `"KO"`가 아닌 `"DE"`로 감지되는 경우가 발생.

### **원인**

1. 텍스트가 URL 인코딩된 상태로 전달되었으나 DeepL API가 이를 올바르게 디코딩하지 못함.
2. DeepL API의 언어 감지 로직이 짧은 텍스트나 특수 문자로 인해 잘못 동작.

### **해결 방안**

- `source_lang`를 명시적으로 설정하여 언어 감지를 강제.

### **코드 적용**

```java
body.add("source_lang", detectedLanguage.toUpperCase()); // 예: KO
body.add("target_lang", targetLanguage.toUpperCase());   // 예: EN
```

---

## **이슈 2: 번역된 텍스트가 URL 인코딩된 상태로 반환됨**

### **문제**

- 번역된 결과가 `%EC%95%88%EB%85%95%ED%95%98%EC%84%B8%EC%9A%94`처럼 URL 인코딩된 상태로 반환됨.

### **원인**

1. DeepL API가 응답 데이터를 URL-safe 포맷으로 반환.
2. 서버에서 해당 데이터를 디코딩하지 않고 그대로 사용.

### **해결 방안**

- 응답 데이터를 `URLDecoder.decode()`를 통해 UTF-8로 디코딩.

### **코드 적용**

```java
java
코드 복사
String translatedText = translations.get(0).get("text");

// URL 디코딩 처리
String decodedText = translatedText;
if (translatedText.contains("%")) {
    decodedText = URLDecoder.decode(translatedText, StandardCharsets.UTF_8);
}

log.info("Translated Text (Decoded): {}", decodedText);
return decodedText;

```

---

## **이슈 3: 단순 텍스트(예: `"hello"`)가 번역되지 않음**

### **문제**

- `"hello"`와 같은 간단한 텍스트가 DeepL API에서 번역되지 않고 원본 그대로 반환.

### **원인**

- DeepL API가 해당 텍스트를 번역할 필요가 없다고 판단.

### **해결 방안**

- 고정 번역 사전을 추가하여 간단한 텍스트는 사전에 정의된 번역 결과를 반환.

### **코드 적용**

```java
java
코드 복사
private static final Map<String, String> fixedTranslations = new HashMap<>();

static {
    fixedTranslations.put("hello", "안녕하세요");
    fixedTranslations.put("goodbye", "안녕히 가세요");
}

if (fixedTranslations.containsKey(text.toLowerCase())) {
    return fixedTranslations.get(text.toLowerCase());
}

```

---

## **이슈 4: GET 요청에서 URL 길이 제한 및 인코딩 문제**

### **문제**

- 긴 텍스트나 특수 문자가 포함된 텍스트가 GET 요청에서 실패.

### **원인**

1. GET 요청의 URL 길이 제한.
2. 특수 문자가 포함된 텍스트가 제대로 인코딩되지 않음.

### **해결 방안**

- POST 요청으로 변경하여 텍스트를 본문(`application/x-www-form-urlencoded`)으로 전달.

### **코드 적용**

```java
java
코드 복사
MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
body.add("auth_key", apiKey);
body.add("text", text);
body.add("source_lang", detectedLanguage.toUpperCase());
body.add("target_lang", targetLanguage.toUpperCase());

HttpHeaders headers = new HttpHeaders();
headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);

HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(body, headers);
ResponseEntity<String> response = restTemplate.postForEntity(endPoint, requestEntity, String.class);

```

---

## **이슈 5: 한글과 영어 텍스트 처리 방식의 차이**

### **문제**

- 영어 텍스트는 URL 인코딩이 필요하지만, 한글 텍스트는 URL 인코딩 없이 전달해야 정상 동작.

### **원인**

- 모든 텍스트를 URL 인코딩하거나, 인코딩하지 않으면 특정 케이스에서 실패.

### **해결 방안**

- `detectLanguage()`를 사용하여 한글과 영어를 구분한 뒤, 조건부로 URL 인코딩 처리.

### **코드 적용**

```java
java
코드 복사
String textToSend = detectedLanguage.equals("ko") ? text : URLEncoder.encode(text, StandardCharsets.UTF_8);

```
