### PR TITLE
22 feat group chat

### DIFF
--- a/src/main/java/personal_project/moment_talk/chat/controller/ChatController.java
+++ b/src/main/java/personal_project/moment_talk/chat/controller/ChatController.java
@@ -3,11 +3,12 @@ package personal_project.moment_talk.chat.controller;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import personal_project.moment_talk.chat.dto.CreateGroupRequest;
 import personal_project.moment_talk.chat.service.DeepLTranslationService;
 import personal_project.moment_talk.common.redis.GroupChatParticipants;
@@ -24,6 +25,7 @@ public class ChatController {
     private final DeepLTranslationService deepLTranslationService;
     private final GroupChatParticipants groupChatParticipants;
     private final GroupChatWebSocketHandler groupChatWebSocketHandler;
+    private final RedisTemplate redisTemplate;
 
     @GetMapping("/1-to-1-chat")
     public String chat() {
@@ -35,6 +37,25 @@ public class ChatController {
         return "group-chat";
     }
 
+
+    @PostMapping("/join")
+    @ResponseBody
+    public ResponseEntity<Map<String, String>> joinRoom(@RequestBody Map<String, String> request, HttpSession httpSession) {
+        String roomId = request.get("roomId");
+        String httpSessionId = httpSession.getId();
+
+        if (roomId == null || roomId.isEmpty()) {
+            return ResponseEntity.badRequest().body(Map.of("message", "Invalid room ID!"));
+        }
+
+        // 그룹 채팅방 참가 로직
+        groupChatWebSocketHandler.handleJoinRoom(roomId, httpSessionId);
+
+        return ResponseEntity.ok(Map.of("message", "User joined the room", "roomId", roomId));
+    }
+
+
+
     @ResponseBody
     @GetMapping("/group-chat/rooms")
     public List<Map<String, String>> groupChatRooms() {
@@ -44,9 +65,31 @@ public class ChatController {
     @PostMapping("/group-chat/rooms")
     @ResponseBody
     public Map<String, String> createGroupChatRoom(@RequestBody CreateGroupRequest request, HttpSession httpSession) {
-        groupChatWebSocketHandler.handleCreateRoom(request.name(), httpSession.getId());
-        return Map.of("message", "Group chat room created successfully", "name", request.name());
+        String roomName = request.name();
+        String httpSessionId = httpSession.getId();
+
+        log.info("Creating room: {} by session: {}", roomName, httpSessionId);
+
+        groupChatWebSocketHandler.handleCreateRoom(roomName, httpSessionId);
+
+        String roomId = (String) redisTemplate.opsForHash().get("chat:rooms", roomName);
+        log.info("Created room ID: {}", roomId);
+
+        // 응답 데이터 확인
+        return Map.of("message", "Group chat room created successfully", "id", roomId, "name", roomName);
     }
+
+//    @GetMapping("/room")
+//    public ResponseEntity<Map<String , String >> getUserRoom(HttpSession httpSession) {
+//        String httpSessionId = httpSession.getId();
+//        String roomId = (String) redisTemplate.opsForHash().get("chat:session_to_room", httpSessionId);
+//
+//        if (roomId == null) {
+//            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+//                    .body(Map.of("message", "User is not part of any room"));
+//        }
+//        return ResponseEntity.ok(Map.of("roomId", roomId));
+//    }
 
     /*
     클라이언트가 보낸 JSON 데이터를 Map<String, String> 형태로 자동 변환

--- a/src/main/java/personal_project/moment_talk/chat/controller/ChatController.java
+++ b/src/main/java/personal_project/moment_talk/chat/controller/ChatController.java
@@ -13,6 +13,7 @@ import personal_project.moment_talk.chat.service.DeepLTranslationService;
 import personal_project.moment_talk.common.redis.GroupChatParticipants;
 import personal_project.moment_talk.common.webSocket.GroupChatWebSocketHandler;
 
+import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -36,7 +37,7 @@ public class ChatController {
 
     @ResponseBody
     @GetMapping("/group-chat/rooms")
-    public Map<String, Map<String, String>> groupChatRooms() {
+    public List<Map<String, String>> groupChatRooms() {
         return groupChatParticipants.getAllGroupChatRooms();
     }
 

--- a/src/main/java/personal_project/moment_talk/chat/controller/ChatController.java
+++ b/src/main/java/personal_project/moment_talk/chat/controller/ChatController.java
@@ -36,7 +36,7 @@ public class ChatController {
 
     @ResponseBody
     @GetMapping("/group-chat/rooms")
-    public Map<Object, Object> groupChatRooms() {
+    public Map<String, Map<String, String>> groupChatRooms() {
         return groupChatParticipants.getAllGroupChatRooms();
     }
 

--- a/src/main/java/personal_project/moment_talk/common/redis/GroupChatParticipants.java
+++ b/src/main/java/personal_project/moment_talk/common/redis/GroupChatParticipants.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -39,7 +40,20 @@ public class GroupChatParticipants {
         return redisTemplate.opsForSet().members(PARTICIPANTS_KEY_PREFIX + roomId + ":participants");
     }
 
-    public Map<Object , Object> getAllGroupChatRooms() {
-        return redisTemplate.opsForHash().entries(ROOM_KEY);
+    public Map<String, Map<String, String>> getAllGroupChatRooms() {
+        Map<Object, Object> rooms = redisTemplate.opsForHash().entries(ROOM_KEY);
+        Map<String, Map<String, String>> returnRooms = new HashMap<>();
+
+        for (Map.Entry<Object, Object> entry : rooms.entrySet()) {
+            String roomName = (String) entry.getKey();
+            String roomId = (String) entry.getValue();
+
+            Map<String, String> roomInfo = new HashMap<>();
+            roomInfo.put("id", roomId);
+            roomInfo.put("name", roomName);
+
+            returnRooms.put(roomName, roomInfo);
+        }
+        return returnRooms;
     }
 }

--- a/src/main/java/personal_project/moment_talk/common/redis/GroupChatParticipants.java
+++ b/src/main/java/personal_project/moment_talk/common/redis/GroupChatParticipants.java
@@ -4,9 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 @Component
@@ -16,10 +15,17 @@ public class GroupChatParticipants {
     private final RedisTemplate<String , Object> redisTemplate;
     private static final String ROOM_KEY = "chat:rooms";
     private static final String PARTICIPANTS_KEY_PREFIX = "chat:room:";
+    private final Map<String, List<String>> chatParticipants = new ConcurrentHashMap<>();
 
-    public void createGroupChatRoom(String roomId, String roomName) {
-        redisTemplate.opsForHash().put(ROOM_KEY, roomId, roomName);
+
+    public void createGroupChatRoom(String roomName, String httpSessionId) {
+        String roomId = UUID.randomUUID().toString();
+        redisTemplate.opsForHash().put(ROOM_KEY, roomName, roomId);
         redisTemplate.expire(PARTICIPANTS_KEY_PREFIX + roomId + ":participants", 1, TimeUnit.DAYS);
+
+        List<String> participants = new ArrayList<>();
+        participants.add(httpSessionId);
+        chatParticipants.put(roomId, participants);
     }
 
     public void deleteGroupChatRoom(String roomId) {
@@ -31,7 +37,6 @@ public class GroupChatParticipants {
         redisTemplate.opsForSet().remove(PARTICIPANTS_KEY_PREFIX + roomId + ":participants", httpSessionId);
     }
 
-
     public void addParticipantToGroupChatRoom(String roomId, String httpSessionId) {
         redisTemplate.opsForSet().add(PARTICIPANTS_KEY_PREFIX + roomId + ":participants", httpSessionId);
     }
@@ -40,20 +45,20 @@ public class GroupChatParticipants {
         return redisTemplate.opsForSet().members(PARTICIPANTS_KEY_PREFIX + roomId + ":participants");
     }
 
-    public Map<String, Map<String, String>> getAllGroupChatRooms() {
+    public  List<Map<String, String>> getAllGroupChatRooms() {
         Map<Object, Object> rooms = redisTemplate.opsForHash().entries(ROOM_KEY);
-        Map<String, Map<String, String>> returnRooms = new HashMap<>();
 
+        List<Map<String, String>> result = new ArrayList<>();
         for (Map.Entry<Object, Object> entry : rooms.entrySet()) {
             String roomName = (String) entry.getKey();
             String roomId = (String) entry.getValue();
 
-            Map<String, String> roomInfo = new HashMap<>();
-            roomInfo.put("id", roomId);
-            roomInfo.put("name", roomName);
+            Map<String, String> roomData = new HashMap<>();
+            roomData.put("id", roomId);
+            roomData.put("name", roomName);
 
-            returnRooms.put(roomName, roomInfo);
+            result.add(roomData);
         }
-        return returnRooms;
+        return result;
     }
 }

--- a/src/main/java/personal_project/moment_talk/common/webSocket/GroupChatWebSocketHandler.java
+++ b/src/main/java/personal_project/moment_talk/common/webSocket/GroupChatWebSocketHandler.java
@@ -11,6 +11,9 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 import personal_project.moment_talk.common.redis.GroupChatParticipants;
 import personal_project.moment_talk.user.repository.UserRepository;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 @Slf4j
@@ -24,8 +27,9 @@ public class GroupChatWebSocketHandler extends TextWebSocketHandler {
     private final UserRepository userRepository;
     private final ObjectMapper objectMapper;
 
-    public void handleCreateRoom(String roomId, String roomName) {
-        groupChatParticipants.createGroupChatRoom(roomId, roomName);
+    //TODO: 생성을 하고 해당 채팅방 페이지로 이동, 해당 그룹 채팅방의 웹소켓 배열에 사용자의 웹소켓 ID 추가 필요.
+    public void handleCreateRoom(String roomName, String httpSessionId) {
+        groupChatParticipants.createGroupChatRoom(roomName, httpSessionId);
     }
 
     private void brodCastMessage(String roomId, String message) {
@@ -43,11 +47,13 @@ public class GroupChatWebSocketHandler extends TextWebSocketHandler {
         }
     }
 
+    //TODO: 해당 채팅방 페이지로 이동, 해당 그룹 채팅방에 해당하는 웹소켓 배열에 사용자의 웹소켓 ID 추가
     public void handleJoinRoom(String roomId, String httpSessionId) {
         groupChatParticipants.addParticipantToGroupChatRoom(roomId, httpSessionId);
         brodCastMessage(roomId, "User joined: " + httpSessionId);
     }
 
+    //TODO: 해당 채팅방 페이지에서 나오고, 그룹 Chat 페이지로 이동, 해당 웹소켓 배열에서 사용자의 웹소켓 ID 제거
     public void handleLeaveRoom(String roomId, String httpSessionId) {
         groupChatParticipants.removeParticipant(roomId, httpSessionId);
         brodCastMessage(roomId, "User left: " + httpSessionId);

--- a/src/main/resources/static/css/group-chat.css
+++ b/src/main/resources/static/css/group-chat.css
@@ -84,3 +84,233 @@ body, html {
 .create-group button:hover {
     background-color: #4e60d9;
 }
+
+.back-button {
+    background-color: #f44336;
+    border: none;
+    color: white;
+    padding: 10px 15px;
+    margin-bottom: 10px;
+    cursor: pointer;
+    border-radius: 5px;
+}
+
+.chat-room-title {
+    font-size: 24px;
+    font-weight: bold;
+    text-align: center;
+    margin-bottom: 10px;
+}
+
+.chat-messages {
+    height: 300px;
+    overflow-y: scroll;
+    border: 1px solid #ddd;
+    padding: 10px;
+    margin-bottom: 10px;
+    background-color: #f9f9f9;
+    border-radius: 5px;
+}
+
+.chat-message {
+    margin-bottom: 10px;
+    padding: 8px;
+    border-radius: 5px;
+    background-color: #e0f7fa;
+    transition: background-color 0.3s ease;
+}
+
+.message-sent {
+    text-align: right;
+    background-color: #d1e7dd;
+}
+
+.message-received {
+    text-align: left;
+    background-color: #f8d7da;
+}
+
+.chat-input {
+    display: flex;
+    gap: 10px;
+}
+
+.chat-input input {
+    flex: 1;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+}
+
+.chat-input button {
+    padding: 10px 15px;
+    background-color: #4caf50;
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+.chat-input button:hover {
+    background-color: #45a049;
+}
+
+.file-upload {
+    text-align: right;
+    margin-top: 10px;
+}
+
+.file-upload button {
+    background-color: #5e72eb;
+    color: white;
+    border: none;
+    padding: 10px;
+    border-radius: 5px;
+    cursor: pointer;
+}
+#chatBox {
+    display: none;
+    flex-direction: column;
+    margin-top: 30px;
+    gap: 20px;
+    height: calc(100% - 60px);
+    width: 100%;
+    box-sizing: border-box; /* Ensure padding doesn't overflow the width */
+    overflow: hidden; /* Prevents unwanted scroll on small screens */
+}
+
+#chatMessages .message-sent {
+    background-color: #667eea;
+    color: #ffffff;
+    align-self: flex-end;
+    margin: 10px 0;
+    padding: 12px 18px;
+    border-radius: 20px 20px 0 20px;
+    max-width: 70%;
+    word-wrap: break-word;
+}
+.message-received, .message-sent {
+    display: flex; /* 기본적으로 보이도록 설정 */
+}
+
+
+.message-hidden {
+    display: none; /* 숨김 상태 */
+}
+.chat-container {
+    display: flex;
+    flex-direction: column;
+    background: #ffffff;
+    border-radius: 15px;
+    padding: 20px;
+    width: 100%;
+    max-width: 600px;
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
+    margin: auto;
+}
+
+.chat-messages {
+    flex: 1;
+    overflow-y: auto;
+    background-color: #1e293b;
+    color: #ffffff;
+    border-radius: 10px;
+    padding: 15px;
+    margin-bottom: 15px;
+    box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+.chat-input {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    background-color: #f8f9fa;
+    border-radius: 10px;
+    padding: 10px;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+.chat-input input[type="text"] {
+    flex: 1;
+    border: none;
+    padding: 10px;
+    border-radius: 5px;
+    outline: none;
+    font-size: 1rem;
+    box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+.chat-input button.send-button {
+    padding: 10px 20px;
+    background: linear-gradient(90deg, #667eea, #764ba2);
+    color: #fff;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 1rem;
+    transition: background 0.3s ease;
+}
+
+.chat-input button.send-button:hover {
+    background: linear-gradient(90deg, #5a67d8, #6b46c1);
+}
+
+.upload-button {
+    font-size: 1.5rem;
+    color: #667eea;
+    cursor: pointer;
+    padding: 5px;
+}
+
+.back-button {
+    background-color: #f44336;
+    color: white;
+    border: none;
+    padding: 10px;
+    border-radius: 5px;
+    margin-bottom: 15px;
+    font-size: 1rem;
+    cursor: pointer;
+}
+
+#chatMessages {
+    flex: 1;
+    border: 1px solid #e2e8f0;
+    border-radius: 20px;
+    overflow-y: auto;
+    padding: 20px;
+    background-color: #1e293b;
+    box-shadow: inset 0 4px 8px rgba(0, 0, 0, 0.1);
+    font-size: 1rem;
+    color: #ffffff;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    box-sizing: border-box; /* Ensure padding doesn't overflow the width */
+}
+
+#chatMessages .message-received {
+    background-color: #4a5568;
+    color: #ffffff;
+    align-self: flex-start;
+    margin: 10px 0;
+    padding: 12px 18px;
+    border-radius: 20px 20px 20px 0;
+    max-width: 70%;
+    word-wrap: break-word;
+    position: relative;
+    display: flex; /* 버튼 정렬을 위한 플렉스 컨테이너 */
+    align-items: center; /* 세로 중앙 정렬 */
+}
+
+
+.file-upload button:hover {
+    background-color: #4e60d9;
+}
+
+.older-message-notice {
+    text-align: center;
+    color: #9e9e9e;
+    font-size: 0.9rem;
+    margin-bottom: 10px;
+}

--- a/src/main/resources/static/js/group-chat.js
+++ b/src/main/resources/static/js/group-chat.js
@@ -5,18 +5,18 @@ function fetchGroupChatRooms() {
             const groupList = document.getElementById('groupList');
             groupList.innerHTML = ''; // Clear current group list
 
-            Object.entries(data).forEach(([key, value]) => {
+            Object.entries(data).forEach(([roomId, roomData]) => {
                 const groupItem = document.createElement('div');
                 groupItem.className = 'group-item';
 
                 const groupName = document.createElement('span');
-                groupName.textContent = value;
+                groupName.textContent = roomData.name; // Use the room name
 
                 const joinButton = document.createElement('button');
                 joinButton.textContent = 'Join';
                 joinButton.onclick = () => {
-                    alert(`Joining group: ${value}`);
-                    // Add your join group logic here
+                    alert(`Joining group: ${roomData.name}`);
+                    // Add your join group logic here (e.g., call another API)
                 };
 
                 groupItem.appendChild(groupName);

--- a/src/main/resources/static/js/group-chat.js
+++ b/src/main/resources/static/js/group-chat.js
@@ -1,3 +1,15 @@
+// Send 버튼 클릭 이벤트 추가
+const sendButton = document.getElementById("sendButton"); // Send 버튼 DOM 요소 가져오기
+const messageInput = document.getElementById("messageInput"); // 메시지 입력창
+const chatMessages = document.getElementById("chatMessages"); // 채팅 메시지 영역
+const createGroup = document.getElementById("createGroup");
+
+sendButton.addEventListener("click", sendMessage); // Send 버튼 클릭 시 sendMessage 호출
+
+// WebSocket 초기화 변수
+let socket = null;
+
+// 단체 채팅방 목록 가져오기
 function fetchGroupChatRooms() {
     fetch('/group-chat/rooms')
         .then(response => response.json())
@@ -10,14 +22,11 @@ function fetchGroupChatRooms() {
                 groupItem.className = 'group-item';
 
                 const groupName = document.createElement('span');
-                groupName.textContent = room.name; // 방 이름 표시
+                groupName.textContent = room.name;
 
                 const joinButton = document.createElement('button');
                 joinButton.textContent = 'Join';
-                joinButton.onclick = () => {
-                    alert(`Joining group: ${room.name}`);
-                    // Join 그룹 로직 추가
-                };
+                joinButton.onclick = () => joinGroupChat(room.id, room.name);
 
                 groupItem.appendChild(groupName);
                 groupItem.appendChild(joinButton);
@@ -27,26 +36,268 @@ function fetchGroupChatRooms() {
         .catch(error => console.error('Error fetching group chat rooms:', error));
 }
 
-// Create a new group
-document.getElementById('createGroup').addEventListener('click', () => {
-    const groupName = document.getElementById('groupName').value;
-    if (groupName.trim() === '') {
-        alert('Group name cannot be empty!');
+
+document.addEventListener("click", async (event) => {
+    if (event.target.classList.contains("translate-button")) {
+        const button = event.target;
+        const originalMessage = button.getAttribute("data-message");
+        const translatedMessage = await translateMessage(originalMessage);
+        button.textContent = translatedMessage;
+    }
+});
+
+async function translateMessage(message) {
+    try {
+        const response = await fetch("/translate", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ text: message }),
+        });
+        const data = await response.json();
+        return data.translatedText;
+    } catch (error) {
+        console.error("Translation error:", error);
+    }
+}
+
+function joinGroupChat(roomId, roomName) {
+    if (!roomId) {
+        alert("Invalid room ID!");
         return;
     }
 
-    fetch('/group-chat/rooms', {
+    console.log(`Joining room with ID: ${roomId}`);
+
+    // 서버에 참가 요청
+    fetch('/join', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: groupName })
+        body: JSON.stringify({ roomId }),
     })
-        .then(response => response.json())
-        .then(data => {
-            alert(`${data.message}: ${data.name}`);
-            fetchGroupChatRooms(); // Refresh the group list after creating a group
+        .then(response => {
+            if (!response.ok) {
+                throw new Error(`Failed to join room: ${response.status}`);
+            }
+            return response.json();
         })
-        .catch(error => console.error('Error creating group:', error));
+        .then(data => {
+            console.log("Join success:", data);
+
+            // UI 업데이트
+            const groupListContainer = document.getElementById('groupListContainer');
+            const chatBox = document.getElementById('chatBox');
+            const groupTitle = document.getElementById('groupTitle');
+            groupTitle.textContent = roomName;
+
+            groupListContainer.style.display = 'none';
+            chatBox.style.display = 'flex';
+
+            // WebSocket 연결 설정
+            connectToRoom(roomId, roomName);
+        })
+        .catch(error => {
+            console.error("Error joining room:", error);
+            alert("Failed to join the room. Please try again.");
+        });
+}
+let reconnectAttempts = 0;
+
+function connectToRoom(roomId, roomName) {
+    if (socket) socket.close();
+
+    socket = new WebSocket(`ws://localhost:8080/ws/group/${roomId}`);
+
+    socket.onopen = () => {
+        console.log(`Connected to room: ${roomName}`);
+        reconnectAttempts = 0; // 재연결 시도 초기화
+    };
+
+    socket.onmessage = (event) => handleWebSocketMessage(event);
+
+    socket.onclose = () => {
+        console.error(`Disconnected from room: ${roomName}`);
+        reconnectAttempts++;
+        const retryTime = Math.min(reconnectAttempts * 1000, 30000); // 최대 30초 지연
+        setTimeout(() => connectToRoom(roomId, roomName), retryTime);
+    };
+
+    socket.onerror = (error) => {
+        console.error("WebSocket error:", error);
+    };
+}
+
+let currentFileMetadata = null;
+
+function handleWebSocketMessage(event) {
+    try {
+        if (typeof event.data === "string") {
+            const parsedData = JSON.parse(event.data);
+
+            if (parsedData.type === "file") {
+                currentFileMetadata = parsedData; // 메타데이터 저장
+            } else if (parsedData.type === "text") {
+                displayMessage(parsedData.content, "received", parsedData.userName);
+            }
+        } else if (event.data instanceof Blob) {
+            if (currentFileMetadata) {
+                const fileUrl = URL.createObjectURL(event.data);
+                displayFileMessage(fileUrl, "received", currentFileMetadata.fileType);
+                currentFileMetadata = null; // 메타데이터 초기화
+            } else {
+                console.error("Metadata not found for received file.");
+            }
+        }
+    } catch (error) {
+        console.error("Error handling WebSocket message:", error);
+    }
+}
+
+// 메시지 전송 함수
+function sendMessage() {
+    const message = messageInput.value.trim();
+
+    if (!message) {
+        console.error("Message is empty. Please type a message before sending.");
+        return;
+    }
+
+    if (!socket || socket.readyState !== WebSocket.OPEN) {
+        console.error("WebSocket is not open. Unable to send the message.");
+        return;
+    }
+
+    // 메시지 객체 생성
+    const messageData = {
+        type: "text",
+        content: message,
+        timestamp: new Date().toISOString(), // 전송 시간
+    };
+
+    try {
+        socket.send(JSON.stringify(messageData)); // WebSocket으로 메시지 전송
+        displayMessage(message, "sent");
+        messageInput.value = ""; // 입력창 초기화
+    } catch (error) {
+        console.error("Error sending message:", error);
+    }
+}
+async function createGroupChat(groupName) {
+    const response = await fetch('/group-chat/rooms', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: groupName }),
+    });
+
+    if (!response.ok) {
+        throw new Error(`Server error: ${response.status}`);
+    }
+
+    const data = await response.json();
+    console.log("Group created successfully:", data);
+    return data; // 생성된 방 정보 반환
+}
+
+document.getElementById("createGroup").addEventListener("click", async () => {
+    const groupNameInput = document.getElementById("groupName");
+    const groupName = groupNameInput.value.trim();
+
+    if (!groupName) {
+        alert("Group name cannot be empty!");
+        return;
+    }
+
+    try {
+        const groupData = await createGroupChat(groupName);
+        alert(`Group "${groupData.name}" created successfully!`);
+        joinGroupChat(groupData.id, groupData.name); // 생성 후 바로 방에 참여
+        groupNameInput.value = ""; // 입력창 초기화
+    } catch (error) {
+        console.error("Error creating group:", error);
+        alert("Failed to create group. Please try again.");
+    }
 });
 
-// Automatically fetch group chat rooms on page load
+
+// 메시지 표시 함수
+function displayMessage(message, messageType, userName = "You") {
+    const messageDiv = document.createElement("div");
+    messageDiv.className = messageType === "sent" ? "message-sent-wrapper" : "message-received-wrapper";
+
+    const timeString = new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+
+    messageDiv.innerHTML = `
+        <div class="message-container">
+            <div class="message-header">
+                <span class="message-username">${userName}</span>
+                <span class="message-time">${timeString}</span>
+            </div>
+            <div class="message-content">${message}</div>
+            ${
+        messageType === "received"
+            ? `<button class="translate-button" data-message="${message}">Translate</button>`
+            : ""
+    }
+        </div>
+    `;
+
+    chatMessages.appendChild(messageDiv);
+    chatMessages.scrollTop = chatMessages.scrollHeight;
+}
+
+
+document.getElementById("backButton").addEventListener("click", resetUI);
+document.getElementById("fileInput").addEventListener("change", async (event) => {
+    const file = event.target.files[0];
+    if (!file) return;
+
+    const metadata = {
+        type: "file",
+        fileName: file.name,
+        fileType: file.type,
+    };
+
+    try {
+        // 메타데이터 전송
+        socket.send(JSON.stringify(metadata));
+
+        // 파일 데이터 전송
+        const arrayBuffer = await file.arrayBuffer();
+        socket.send(arrayBuffer);
+
+        // 송신자 UI에 파일 표시
+        displayFileMessage(URL.createObjectURL(file), "sent", file.type);
+
+        // 파일 선택 초기화
+        event.target.value = "";
+    } catch (error) {
+        console.error("Error sending file:", error);
+    }
+});
+function displayFileMessage(fileUrl, messageType, fileType = "") {
+    const messageDiv = document.createElement("div");
+    messageDiv.className = messageType === "sent" ? "message-sent" : "message-received";
+
+    if (fileType.startsWith("image")) {
+        messageDiv.innerHTML = `<img src="${fileUrl}" alt="Image" style="max-width: 100%; border-radius: 10px;">`;
+    } else if (fileType.startsWith("video")) {
+        messageDiv.innerHTML = `<video src="${fileUrl}" controls style="max-width: 100%; border-radius: 10px;"></video>`;
+    } else {
+        messageDiv.innerHTML = `<a href="${fileUrl}" download style="color: #4e60d9; text-decoration: underline;">Download File</a>`;
+    }
+
+    chatMessages.appendChild(messageDiv);
+    chatMessages.scrollTop = chatMessages.scrollHeight;
+}
+
+function resetUI() {
+    document.getElementById("groupListContainer").style.display = "block";
+    document.getElementById("chatBox").style.display = "none";
+    chatMessages.innerHTML = "";
+    if (socket) {
+        socket.close(); // WebSocket 종료
+        socket = null;
+    }
+}
+
+// 페이지 로드 시 그룹 목록 가져오기
 window.onload = fetchGroupChatRooms;

--- a/src/main/resources/static/js/group-chat.js
+++ b/src/main/resources/static/js/group-chat.js
@@ -3,20 +3,20 @@ function fetchGroupChatRooms() {
         .then(response => response.json())
         .then(data => {
             const groupList = document.getElementById('groupList');
-            groupList.innerHTML = ''; // Clear current group list
+            groupList.innerHTML = ''; // 현재 리스트 초기화
 
-            Object.entries(data).forEach(([roomId, roomData]) => {
+            data.forEach(room => {
                 const groupItem = document.createElement('div');
                 groupItem.className = 'group-item';
 
                 const groupName = document.createElement('span');
-                groupName.textContent = roomData.name; // Use the room name
+                groupName.textContent = room.name; // 방 이름 표시
 
                 const joinButton = document.createElement('button');
                 joinButton.textContent = 'Join';
                 joinButton.onclick = () => {
-                    alert(`Joining group: ${roomData.name}`);
-                    // Add your join group logic here (e.g., call another API)
+                    alert(`Joining group: ${room.name}`);
+                    // Join 그룹 로직 추가
                 };
 
                 groupItem.appendChild(groupName);

--- a/src/main/resources/templates/group-chat.html
+++ b/src/main/resources/templates/group-chat.html
@@ -8,17 +8,50 @@
 </head>
 <body>
 <div class="container">
+    <!-- Header -->
     <div class="header">Group Chat</div>
 
-    <div class="group-list" id="groupList">
-        <!-- Group list items will be dynamically injected here -->
+    <!-- Group List Section -->
+    <div id="groupListContainer">
+        <div id="groupList" class="group-list"></div>
+        <div class="create-group">
+            <input type="text" id="groupName" placeholder="Enter group name">
+            <button id="createGroup">Create Group</button>
+        </div>
     </div>
 
-    <div class="create-group">
-        <input type="text" id="groupName" placeholder="Enter group name">
-        <button id="createGroup">Create Group</button>
+    <!-- Chat Section -->
+    <!-- Chat Section -->
+    <div id="chatBox" style="display: none;">
+        <!-- Back Button -->
+        <button id="backButton" class="back-button">Back</button>
+
+        <!-- Group Title -->
+        <h1 id="groupTitle" class="chat-room-title"></h1>
+
+        <!-- Chat Messages -->
+        <div id="chatMessages" class="chat-messages">
+            <!-- Older Messages Notice -->
+            <div id="olderMessageNotice" class="older-message-notice" style="display: none;">
+                Messages older than 5 minutes are hidden.
+            </div>
+        </div>
+
+        <!-- Chat Input and File Upload -->
+        <div class="chat-input-container">
+            <div class="chat-input">
+                <input id="messageInput" type="text" placeholder="Type your message...">
+                <button id="sendButton">Send</button>
+            </div>
+            <div class="file-upload">
+                <input type="file" id="fileInput" style="display: none;" accept="image/*,video/*,application/*">
+                <label for="fileInput" id="fileUploadButton" class="upload-button">📎 Upload File</label>
+            </div>
+        </div>
     </div>
 </div>
+
+<!-- Scripts -->
 <script src="/js/group-chat.js" th:src="@{/js/group-chat.js}"></script>
 </body>
 </html>


### PR DESCRIPTION
원래 계획 ->
채팅 매칭 페이지에서 매칭하기 -> 매칭이 되면 다른 페이지로 이동해 채팅 시작

그러나 웹소켓은 url이 바뀔때 이전의 웹소켓을 유지 할 수 없어 새로운 페이지로 이동해 웹소켓을 새로 연결을 해야 한다.

매칭을 할 때 연결한 웹소켓을 유지하기 위해 같은 페이지에서 채팅 시작

단체 채팅에서는 일대일 채팅과 거의 모든 로직 동일

일대일 채팅과 다르게 매칭이 잡혀야 채팅을 시작하는 것이 아니라 채팅방을 생성하거나 참가하기 버튼을 누르면 바로 채팅창으로 이동

채팅창으로 이동할 때 webSocketSession 의 주소에 해당 채팅방의 id를 추가

채팅방의 id 와 해당 채팅방에 참가한 참가자의 httpSessionId 리스트를 redis에 저장

메시지를 전송할 때 브로드캐스트 형식으로 전송하기 위해 redis에 있는 리스트의 참가자 모두에게 sendMessage

-> 현재까지 구현한 것은 기본적인 틀
-> 코드 중복 제거, 리팩토링 필요, 현재는 4명의 인원까지 들어올 수 있는 것을 확인 그러나 사진이나 영상을 보낼 때 4명의 참가자에게 전송할 때 이미지가 깨지는 현상 확인 -> 이슈 해결 필요